### PR TITLE
Add jsPsych version check before starting experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@ A utility wrapper library extending the functionality of jsPsych-based cognitive
 
 ## Features
 
-### [jsPsych](https://www.jspsych.org/6.3/) included
-
-Neurcog is bundled to include jsPsych version 6.3, and it does not currently support any jsPsych 7 versions.
-
 ### [Gorilla](https://gorilla.sc) integration
 
 Facilitates interaction with parts of the Gorilla API. Load and access stimuli, access manipulations, and update stored data while maintaining the same codebase online and offline. The wrapper library detects what context the experiment is running in and makes API calls accordingly.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Neurocog.js
 
-<img src="https://raw.githubusercontent.com/Brain-Development-and-Disorders-Lab/Neurocog.js/main/icon.png" alt="Neurocog.js icon" width="200"/>
+<img src="https://raw.githubusercontent.com/Brain-Development-and-Disorders-Lab/Neurocog.js/main/icon.png" alt="Neurocog.js icon" width="200" style="display: block; margin-left: auto; margin-right: auto;"/>
 
 A utility wrapper library extending the functionality of jsPsych-based cognitive tasks and enabling multiplatform operation, designed to extend your jsPsych experiment with new features and capabilities.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import type {
 } from "../types";
 
 // Utility functions
-import { checkContext, clear, clearTimeouts } from "./lib/functions";
+import { checkEnvironment, clear, clearTimeouts } from "./lib/functions";
 
 // Logging library
 import consola from "consola";
@@ -105,7 +105,7 @@ export class Experiment {
     this.stimuliCollection = new Stimuli(this.config.stimuli);
 
     // Check the context of the script to try and catch any errors
-    if (checkContext() === false) {
+    if (checkEnvironment() === false) {
       consola.error(new Error("Context check failed, halting experiment"));
     } else {
       // Load all stimuli used in the Experiment.

--- a/src/lib/functions.ts
+++ b/src/lib/functions.ts
@@ -58,15 +58,15 @@ export const clearTimeouts = (timeouts?: number[]): void => {
  * Important utility function used to enforce loading the script with
  * the 'defer' attribute set correctly on Gorilla.
  */
-export const checkContext = (): boolean => {
-  // Get the current script
-  const scriptElement = document.currentScript;
-
+export const checkEnvironment = (): boolean => {
   // Status flag
   let status = true;
 
+  // Get the current script
+  const scriptElement = document.currentScript;
+
   // Collect a list of potential errors
-  const contextErrors = {
+  const scriptElementErrors = {
     defer: false,
     gorilla: false,
   };
@@ -74,14 +74,14 @@ export const checkContext = (): boolean => {
   // Run checks on how the script was loaded
   if (scriptElement !== null) {
     // Check 1: was the 'defer' flag set?
-    contextErrors.defer = (scriptElement as HTMLScriptElement).defer;
+    scriptElementErrors.defer = (scriptElement as HTMLScriptElement).defer;
 
     // Check 2: check if we are running on Gorilla? This check doesn't need
     // to check for the API, we just check the current window location.
-    contextErrors.gorilla = window.location.href.includes("gorilla");
+    scriptElementErrors.gorilla = window.location.href.includes("gorilla");
 
     // Generate any error messages
-    if (contextErrors.gorilla === true && contextErrors.defer === false) {
+    if (scriptElementErrors.gorilla === true && scriptElementErrors.defer === false) {
       // 'defer' was not specified when required
       consola.error(
         new Error(
@@ -93,8 +93,8 @@ export const checkContext = (): boolean => {
       // Context check didn't pass
       status = false;
     } else if (
-      contextErrors.gorilla === false &&
-      contextErrors.defer === false
+      scriptElementErrors.gorilla === false &&
+      scriptElementErrors.defer === false
     ) {
       // 'defer' was not specified, but not required
       consola.warn(`Script element missing 'defer' attribute`);
@@ -105,6 +105,19 @@ export const checkContext = (): boolean => {
   } else {
     // Log a warning
     consola.warn(`Context not checked`);
+  }
+
+  // Check the version of jsPsych
+  const version: string = window.jsPsych.version();
+  if (!version.startsWith("6.")) {
+
+    // Unsupported version, log error
+    consola.error(
+      new Error(`jsPsych version "${version}" is not supported at this time`)
+    );
+
+    // Context check didn't pass
+    status = false;
   }
 
   return status;


### PR DESCRIPTION
- Rename `checkContext` utility function to `checkEnvironment`
- Add jsPsych version check, enforcing support only for jsPsych versions 6.*
- Improve clarity of documentation